### PR TITLE
Enable config plugin api to support function - WIP

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -187,8 +187,12 @@ export interface PluginFactory extends Plugin {
 	create(plugin: Plugin): Plugin
 }
 
+export interface MergeWithCurrentConfig<M extends Models = Models> {
+	(currentConfig: InitConfig<M>): InitConfig<M>
+}
+
 export interface Plugin<M extends Models = Models, A extends Action = Action> {
-	config?: InitConfig<M>
+	config?: InitConfig<M> | MergeWithCurrentConfig<M>
 	onInit?: () => void
 	onStoreCreated?: (store: RematchStore<M, A>) => void
 	onModel?: ModelHook

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -187,12 +187,8 @@ export interface PluginFactory extends Plugin {
 	create(plugin: Plugin): Plugin
 }
 
-export interface MergeWithCurrentConfig<M extends Models = Models> {
-	(currentConfig: InitConfig<M>): InitConfig<M>
-}
-
 export interface Plugin<M extends Models = Models, A extends Action = Action> {
-	config?: InitConfig<M> | MergeWithCurrentConfig<M>
+	config?: InitConfig<M> | ((initConfig: InitConfig<M>) => InitConfig<M>)
 	onInit?: () => void
 	onStoreCreated?: (store: RematchStore<M, A>) => void
 	onModel?: ModelHook

--- a/src/utils/mergeConfig.ts
+++ b/src/utils/mergeConfig.ts
@@ -68,7 +68,7 @@ export default (initConfig: R.InitConfig & { name: string }): R.Config => {
 
 	// defaults
 	for (const plugin of config.plugins) {
-		let pluginConfig = isFunction(plugin.config) ? plugin.config(config) : plugin.config
+		const pluginConfig = isFunction(plugin.config) ? plugin.config(config) : plugin.config
 
 		if (pluginConfig) {
 			// models


### PR DESCRIPTION
Hi @ShMcK and @pjamrozowicz  ,

Thank you for your reply. To demonstrate what I really want to achieve. I have created a pr in my own forked rematch repo. 
https://github.com/sdujack2012/rematch/pull/1
Please have a look when you have time.

This feature helps create plugins that are smarter and more 'responsible'. With this feature we can have the following benefits:

1. It is 100% backward compatible. The plugin config can either be a object(existing) or a function(new) so existing plugins will still work and new plugins can be created the same way. The original merge logic is intact. It only changes the way a plugin's config is generated

2. Plugins that aim to create dynamic reducers or enhance existing reducers can be easily implemented. Config plugin api is the currently the only place where you can add/enhance reducers for models(which should stay the same way). With 'models' readily available in 'currentConfig' a plugin can create reducers automatically according to the context provided by 'models'. Immer plugin could also be improved to not rely on combineReducers since it could have access to individual reducers in models if this feature were available. It could just wrap reducers with 'produce' one by one to avoid changing combineReducers.

3. It also helps a plugin to deal with conflicts with other plugins on something that is tricky to merge such as combineReducers and createStore. By having the knowledge of the config that is currently applied, a plugin can choose to adapt to it or to throw warnings when it is impossible to be compatible. This prevents plugins from overriding something blindly and causing itself or other plugins to fail silently much like Immer and Persist plugin at the moment.

The PR is WIP. I haven't done the unit tests bit for the new feature let me know if you are fine with it then I will continue on the rest of the work.

Cheers,
Kai